### PR TITLE
add look ahead for unpackTags

### DIFF
--- a/elements.go
+++ b/elements.go
@@ -114,7 +114,7 @@ func way(o OSMReader, pb *OSMPBF.PrimitiveBlock, ways []*OSMPBF.Way, infoFn info
 		w.ID = way.GetId()
 		nodeID = 0
 		w.NodeIDs = make([]int64, len(way.Refs))
-		w.Tags = make(map[string]string)
+		w.Tags = make(map[string]string, len(way.Keys))
 		for pos, key := range way.Keys {
 			keyString := string(st[int(key)])
 			w.Tags[keyString] = string(st[way.Vals[pos]])
@@ -141,7 +141,7 @@ func relation(o OSMReader, pb *OSMPBF.PrimitiveBlock, relations []*OSMPBF.Relati
 			relMember RelationMember
 			memID     int64
 		)
-		r.Tags = make(map[string]string)
+		r.Tags = make(map[string]string, len(rel.Keys))
 		for pos, key := range rel.Keys {
 			keyString := string(st[int(key)])
 			r.Tags[keyString] = string(st[rel.Vals[pos]])

--- a/tags.go
+++ b/tags.go
@@ -1,7 +1,13 @@
 package gosmparse
 
 func unpackTags(st []string, pos int, kv []int32) (int, map[string]string) {
-	tags := map[string]string{}
+	// Look ahead to know how much space to allocate
+	var end int = pos
+	for end < len(kv) && kv[end] != 0 {
+		end = end + 2
+	}
+
+	tags := make(map[string]string, (end-pos)/2)
 	for pos < len(kv) {
 		if kv[pos] == 0 {
 			pos++


### PR DESCRIPTION
By doing two runs through the array, we can determine the exact
size of the map we should allocate ahead of time. In an added
benchmark, allocations per unpack and time per unpack are
reduced by about 20% across the board:
```
name          old time/op    new time/op    delta
UnpackTags-8    7.95µs ± 1%    6.29µs ± 7%  -20.90%  (p=0.029 n=4+4)

name          old alloc/op   new alloc/op   delta
UnpackTags-8    10.3kB ± 0%     7.9kB ± 0%  -23.22%  (p=0.029 n=4+4)

name          old allocs/op  new allocs/op  delta
UnpackTags-8      40.0 ± 0%      33.0 ± 0%  -17.50%  (p=0.029 n=4+4)
```